### PR TITLE
added cpu metrics, fails if no file found

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,17 +6,22 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 
 module.exports = {
-    "extends": "problems",
+    "extends": [
+        "problems"
+    ],
     "env": {
         "node": true
     },
     "parserOptions": {
         "ecmaVersion": 2018
     },
+    "plugins": [
+        "mocha"
+    ],
     "rules": {
         "prefer-arrow-callback": 0,
         "prefer-template": 1,
@@ -26,5 +31,26 @@ module.exports = {
         "no-console": [0, {"allow": true}],
 
         "template-curly-spacing": [1, "never"],
+
+        // mocha rules intended to catch common problems:
+        // - tests marked with .only() is usually only during development
+        // - tests with identical titles are confusing
+        // - tests defined using () => {} notation do not have access to globals
+        // - tests nested in tests is confusing
+        // - empty tests point to incomplete code
+        // - mocha allows for synch tests, async tests using 'done' callback,
+        //   async tests using Promise. Combining callback and a return of some value
+        //   indicates mixing up the test types
+        // - multiple before/after hooks in a single test suite/test is confusing
+        // - passing async functions to describe() is usually wrong, the individual tests
+        //   can be async however
+        "mocha/no-exclusive-tests": "error",
+        "mocha/no-identical-title": "error",
+        "mocha/no-mocha-arrows": "error",
+        "mocha/no-nested-tests": "error",
+        "mocha/no-pending-tests": "error",
+        "mocha/no-return-and-callback": "error",
+        "mocha/no-sibling-hooks": "error",
+        "mocha/no-async-describe": "error"
     }
 };

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Calculated values:
 - `containerUsage()`: `stats.rss` + `kmem.usage_in_bytes`
 - `containerUsagePercentage()`:`stats.rss` + `kmem.usage_in_bytes` / `limit_in_bytes`
 
+### CPU Metrics:
+[CPU](https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt) reads from path `/sys/fs/cgroup/`:
+
+- `cpuacct.usage`: total CPU time (in nanoseconds) obtained by this cgroup (CPU time obtained by all the tasks)
+in the system
+- `cpuacct.stat`: reports the user and system CPU time consumed by all tasks in this cgroup (including tasks lower in the hierarchy):
+    - `user`: CPU time (in nanoseconds) spent by tasks of the cgroup in user mode
+    - `system`: CPU time (in nanoseconds) spent by tasks of the cgroup in kernel mode
+- `cpuacct.usage_percpu`: CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup (including tasks lower in the hierarchy).
+
 
 ### Installation
 
@@ -26,29 +36,43 @@ npm install cgroup-metrics
 
 ```javascript
 const cgroup = require('cgroup-metrics');
+
+// You can access each metric separately using the async functions for each metric
+
+// Memory Metrics
 const memory = cgroup.memory();
+const containerUsage = await memory.containerUsage();
+console.log(containerUsage);
 
-// cgroup.memory() returns a promise
-memory.containerUsage().then((res) => {
-    console.log(res);
-});
-memory.containerUsagePercentage().then((res) => {
-    console.log(res)
-})
+const containerUsagePercentage = await memory.containerUsagePercentage(containerUsage);
+console.log(containerUsagePercentage);
 
-// Or in an async function:
-async function getContainerUsage() {
-    const containerUsage = await memory.containerUsage();
-    console.log(containerUsage);
+// CPU Metrics
+const cpu = cgroup.cpu();
+const cpuacct_usage = await cpu.usage();
+console.log(`Total CPU usage: ${cpuacct_usage}`);
 
-    const containerUsagePercentage = await memory.containerUsagePercentage(containerUsage);
-    console.log(containerUsagePercentage);
-}
-getContainerUsage();
+const cpuacct_stats = await cpu.stat();
+console.log(`CPU user count: ${cpuacct_stat.user}`);
+console.log(`CPU system count: ${cpuacct_stat.system}`);
+
+const cpuacct_usage_percpu = await cpu.usage_percpu();
+console.log(`CPU usage per CPU task: ${cpuacct_usage_percpu}`);
+
+// Or you can use the function `getAllMetrics` to get an object of all the metrics
+const metrics = await cgroup.getAllMetrics();
+
+console.log(`Container usage: ${metrics.memory.containerUsage}`);
+console.log(`Container usage percentage: ${metrics.memory.containerUsagePercentage}`);
+
+console.log(`Total CPU usage: ${metrics.cpuacct.usage}`);
+console.log(`CPU user count: ${metrics.cpuacct.stat.user}`);
+console.log(`CPU system count: ${metrics.cpuacct.stat.system}`);
+console.log(`CPU usage per CPU task: ${metrics.cpuacct.usage_percpu}`);
 ```
 ### Error Handling
 
-If there is no container running or there is an issue reading the file path, the function call will return `null`
+If there is no container running or there is an issue reading the file path, the function call will error
 
 ### Contributing
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 
 'use strict';
@@ -18,52 +18,111 @@ const fs = require('fs');
  */
 function memory() {
     return {
-        containerUsage: async function() {
-            const rss = await readMetric('stat');
-            const kmemUsage = await readMetric('kmem.usage_in_bytes');
+        containerUsage: async () => {
+            const rss = await readMetric('memory/memory.stat');
+            const kmemUsage = await readMetric('memory/memory.kmem.usage_in_bytes');
             if (rss !== null && kmemUsage !== null) {
                 return (rss + kmemUsage);
             }
             return null
         },
-        containerUsagePercentage: async function(containerUsage=false) {
+        containerUsagePercentage: async (containerUsage=false) => {
             if (!(containerUsage)) {
-                const rss = await readMetric('stat');
-                const kmemUsage = await readMetric('kmem.usage_in_bytes');
+                const rss = await readMetric('memory/memory.stat');
+                const kmemUsage = await readMetric('memory/memory.kmem.usage_in_bytes');
                 containerUsage = (rss !== null && kmemUsage !== null)? (rss + kmemUsage): null;
             }
-            const limit = await readMetric('limit_in_bytes');
+            const limit = await readMetric('memory/memory.limit_in_bytes');
             if (containerUsage !== null && limit !== null) {
                 return ((containerUsage) / limit);
             }
             return null
-        } 
+        }
     }
 }
 
 /**
- * Reads metrics from `/sys/fs/cgroup/memory`
- * @param {String} metric What metric to read from `/sys/fs/cgroup/memory`
- * @returns metric value
+ * Reads metrics from `/sys/fs/cgroup/cpuacct`
+ * @returns Three asyncronous functions `usage`, `stat`, and `usage_percpu`
  */
-function readMetric(metric) {
-    return new Promise((resolve, reject) => {
-        fs.readFile(`/sys/fs/cgroup/memory/memory.${metric}`, function (err, data) {
-            if (err) {
-                // Error reading '/sys/fs/cgroup/memory/memory.${metric}'
-                return reject(err);
-            }
-            else if (metric === 'stat') {
-                // get rss
-                const rss = data.toString().split('\n')[1].split(' ')[1];
-                resolve(parseFloat(rss));   
-            }
-            resolve(parseFloat(data.toString()));   
-        })
-    }).catch(() => {
-        return null;
-    })
-   
+function cpu() {
+    return {
+
+        // returns a value
+        usage: async () => {
+            return readMetric('cpuacct/cpuacct.usage');
+        },
+
+        // returns an object {user: <user-cpu-amount> , system: <system-cpu-amount>}
+        stat: async () => {
+            const stat = await readMetric('cpuacct/cpuacct.stat');
+            return stat
+        },
+
+        // returns a list of cpu usages by task
+        usage_percpu: async () => {
+            return readMetric('cpuacct/cpuacct.usage_percpu');
+        }
+
+    }
 }
 
-module.exports = { memory }
+/**
+ * Calls cpu() and memory() functions to get all metrics at once
+ * @returns {Object} map of each metric to its result
+ */
+async function getAllMetrics() {
+
+    const memory_container_usage = await memory().containerUsage();
+    const memory_container_usage_perc = await memory().containerUsagePercentage(memory_container_usage);
+
+    const cpuacct_usage = await cpu().usage();
+    const cpuacct_stat = await cpu().stat();
+    const cpuacct_usage_percpu = await cpu().usage_percpu();
+
+    return {
+        memory: {
+            containerUsage: memory_container_usage,
+            containerUsagePercentage: memory_container_usage_perc,
+        },
+        cpuacct: {
+            usage: cpuacct_usage,
+            stat: cpuacct_stat,
+            usage_percpu: cpuacct_usage_percpu
+        }
+    }
+}
+
+
+/**
+ * Reads metrics from `/sys/fs/cgroup/`
+ * @param {String} metric What metric to read from `/sys/fs/cgroup/`
+ * @returns metric value
+ */
+async function readMetric(metric) {
+    try {
+        const data = fs.readFileSync(`/sys/fs/cgroup/${metric}`)
+        if (metric === 'memory/memory.stat') {
+                // get rss
+                const rss = data.toString().split('\n')[1].split(' ')[1];
+                return(parseFloat(rss));
+        }
+        if (metric === 'cpuacct/cpuacct.stat') {
+            const user = data.toString().split('\n')[0].split(' ')[1];
+            const system = data.toString().split('\n')[1].split(' ')[1];
+            return {user: user, system: system};
+        }
+        if (metric === 'cpuacct/cpuacct.usage_percpu') {
+            return data.toString().trim().split(' ');
+        }
+        return(parseFloat(data.toString()));
+    } catch (e) {
+        throw Error(`Error reading file /sys/fs/cgroup/${metric}, Message: ${e.message || e}`)
+    }
+}
+
+module.exports = {
+    memory,
+    cpu,
+    getAllMetrics
+ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,17 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "requires": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -232,7 +243,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -271,7 +281,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -285,12 +294,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -347,6 +360,15 @@
       "resolved": "https://registry.npmjs.org/eslint-config-problems/-/eslint-config-problems-2.0.0.tgz",
       "integrity": "sha512-4QbWmmkyf85cmuTGeqrXNRk3wxDEG9meV3Ss4iH8x5EbqJL200MJZkuK3CNJxNWLWl9sxHVXeJlyPaQIgjBS3w==",
       "dev": true
+    },
+    "eslint-plugin-mocha": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.1.1.tgz",
+      "integrity": "sha512-p/otruG425jRYDa28HjbBYYXoFNzq3Qp++gn5dbE44Kz4NvmIsSUKSV1T+RLYUcZOcdJKKAftXbaqkHFqReKoA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.26.1"
+      }
     },
     "eslint-scope": {
       "version": "4.0.2",
@@ -434,12 +456,6 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
-    },
-    "expect.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
-      "dev": true
     },
     "external-editor": {
       "version": "3.0.3",
@@ -537,8 +553,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -591,7 +606,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -605,8 +619,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "he": {
       "version": "1.2.0",
@@ -658,8 +671,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.2.2",
@@ -705,6 +717,11 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -714,20 +731,31 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
+    },
+    "is-nan": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+      "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+      "requires": {
+        "define-properties": "^1.1.1"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -739,7 +767,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -754,7 +781,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -1009,11 +1035,15 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -1025,6 +1055,17 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
@@ -1189,6 +1230,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -1249,6 +1296,11 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1429,6 +1481,18 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "util": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
   ],
   "author": "Jamie Delbick",
   "dependencies": {
+    "assert": "^2.0.0",
     "fs": "^0.0.1-security"
   },
   "devDependencies": {
     "eslint": "^5.15.1",
     "eslint-config-problems": "^2.0.0",
-    "expect.js": "^0.3.1",
+    "eslint-plugin-mocha": "^6.1.1",
     "mocha": "^6.2.0",
     "mockery": "^2.1.0"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,35 +6,51 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 
-const expect = require('expect.js');
+'use strict';
+
+/* eslint-env mocha */
+/* eslint mocha/no-mocha-arrows: "off" */
+
+const assert = require('assert');
 const mockery = require('mockery');
 
 // mock the fs readFile function for testing
 const fsMock = {
-    readFile: function (path, cb) { 
+    readFileSync: function (path) {
         if (path === '/sys/fs/cgroup/memory/memory.stat') {
-            return (cb(null, 'cache 2453\nrss 1234\n'));
+            return ('cache 2453\nrss 1234\n');
         }
         if (path === '/sys/fs/cgroup/memory/memory.kmem.usage_in_bytes') {
-            return (cb(null,'5432'));
+            return ('5432');
         }
         if (path === '/sys/fs/cgroup/memory/memory.limit_in_bytes') {
-            return (cb(null,'9999'));
+            return ('9999');
         }
-        return(cb('file path not found', null));
+        if (path === '/sys/fs/cgroup/cpuacct/cpuacct.usage') {
+            return ('1000');
+        }
+        if (path === '/sys/fs/cgroup/cpuacct/cpuacct.stat') {
+            return ('user 2000\nsystem 3000\n');
+        }
+        if (path === '/sys/fs/cgroup/cpuacct/cpuacct.usage_percpu') {
+            return ('225049880 964460277 1520937451 464329645\n');
+        }
+        return('file path not found');
      }
 };
 
 
 describe('cgroup Metrics', function() {
+
     afterEach(() => {
-        mockery.deregisterMock(fsMock);
+        mockery.deregisterMock('fs');
         mockery.disable();
     })
-    it('should return the same value as reading the file system', function() {
+
+    it('should return the same value as reading the mocked value in the file system', async () => {
         mockery.enable({
             warnOnUnregistered: false,
             useCleanCache:true
@@ -42,24 +58,15 @@ describe('cgroup Metrics', function() {
         mockery.registerMock('fs', fsMock);
         const cgroup = require('../index');
         const memory = cgroup.memory();
-        
-        // using async funtion
-        async function getContainerUsage() {
-            const containerUsage = await memory.containerUsage();
-            expect(containerUsage).to.be(6666);
-            
-            const containerUsagePercentage = await memory.containerUsagePercentage(); 
-            expect(containerUsagePercentage).to.be(6666/9999);
-        }
-        getContainerUsage();
-        
-        // using promises
-        memory.containerUsage().then((res) => {
-            expect(res).to.be(6666);
-        })
+
+        const containerUsage = await memory.containerUsage();
+        assert.equal(containerUsage, 6666);
+
+        const containerUsagePercentage = await memory.containerUsagePercentage();
+        assert.equal(containerUsagePercentage, 6666/9999);
     });
 
-    it('should return the same value as reading the file system with containerUsage', function() {
+    it('should return the same value as reading the mocked memory value in the file system with containerUsage', async () => {
         mockery.enable({
             warnOnUnregistered: false,
             useCleanCache:true
@@ -67,34 +74,92 @@ describe('cgroup Metrics', function() {
         mockery.registerMock('fs', fsMock);
         const cgroup = require('../index');
         const memory = cgroup.memory();
-        
-        // using async funtion
-        async function getContainerUsage() {
-            const containerUsage = await memory.containerUsage();
-            expect(containerUsage).to.be(6666);
-            
-            const containerUsagePercentage = await memory.containerUsagePercentage(containerUsage); 
-            expect(containerUsagePercentage).to.be(6666/9999);
-        }
-        getContainerUsage();
-        
-        // using promises
-        memory.containerUsage().then((res) => {
-            expect(res).to.be(6666);
-        })
+
+        const containerUsage = await memory.containerUsage();
+        assert.equal(containerUsage, 6666);
+
+        const containerUsagePercentage = await memory.containerUsagePercentage(containerUsage);
+        assert.equal(containerUsagePercentage, 6666/9999);
+
     });
 
-    it('should return null if there is no container running', function() {
+    it('should return the same value as reading the mocked value in the file system for cpu', async () => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache:true
+        });
+        mockery.registerMock('fs', fsMock);
+        const cgroup = require('../index');
+        const cpu = cgroup.cpu();
+
+
+        const usage = await cpu.usage();
+        assert.equal(usage, 1000);
+
+        const stat = await cpu.stat();
+        assert.equal(stat.user, 2000);
+        assert.equal(stat.system, 3000);
+
+        const usage_percpu = await cpu.usage_percpu();
+        assert.equal(usage_percpu[1], 964460277);
+        assert.equal(usage_percpu[3], 464329645);
+
+    });
+
+    it('should get all metrics', async () => {
+        mockery.enable({
+            warnOnUnregistered: false,
+            useCleanCache:true
+        });
+        mockery.registerMock('fs', fsMock);
+        const { getAllMetrics } = require('../index');
+
+
+        const metrics = await getAllMetrics();
+
+        console.log(`Container usage: ${metrics.memory.containerUsage}`);
+        console.log(`Container usage percentage: ${metrics.memory.containerUsagePercentage}`);
+
+        console.log(`Total CPU usage: ${metrics.cpuacct.usage}`);
+        console.log(`CPU user count: ${metrics.cpuacct.stat.user}`);
+        console.log(`CPU system count: ${metrics.cpuacct.stat.system}`);
+        console.log(`CPU usage per CPU task: ${metrics.cpuacct.usage_percpu}`);
+        assert.equal(metrics.memory.containerUsage, 6666);
+        assert.equal(metrics.memory.containerUsagePercentage, 6666/9999);
+        assert.equal(metrics.cpuacct.stat.user, 2000);
+        assert.equal(metrics.cpuacct.stat.system, 3000);
+        assert.equal(metrics.cpuacct.usage_percpu[1], 964460277);
+        assert.equal(metrics.cpuacct.usage, 1000);
+    });
+
+    it('should return an error if there is no container running', async () => {
         const cgroup = require('../index');
         const memory = cgroup.memory();
-        
-        // using promises
-        memory.containerUsage().then((res) => {
-            expect(res).to.be(null);
-        });
-        memory.containerUsagePercentage().then((res) => {
-            expect(res).to.be(null);
-        });
+
+        try {
+            await memory.containerUsage();
+            assert.fail('failure expected');
+        } catch (e) {
+            console.log(`test expected to fail: ${e}`)
+            assert.equal(e.message, "Error reading file /sys/fs/cgroup/memory/memory.stat, Message: ENOENT: no such file or directory, open '/sys/fs/cgroup/memory/memory.stat'")
+        }
     });
+
+    it('should fail for cpu usage if there is no container running', async () => {
+        const cgroup = require('../index');
+        const cpu = cgroup.cpu();
+
+        try {
+            await cpu.usage();
+            assert.fail('failure expected');
+        } catch (e) {
+            console.log(`test expected to fail: ${e}`)
+            assert.equal(e.message, "Error reading file /sys/fs/cgroup/cpuacct/cpuacct.usage, Message: ENOENT: no such file or directory, open '/sys/fs/cgroup/cpuacct/cpuacct.usage'")
+        }
+    });
+
+    after( () => {
+        mockery.deregisterAll();
+    })
 
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added CPU metrics: 
- `cpuacct.usage`: total CPU time (in nanoseconds) obtained by this cgroup (CPU time obtained by all the tasks)
in the system
- `cpuacct.stat`: reports the user and system CPU time consumed by all tasks in this cgroup (including tasks lower in the hierarchy):
    - `user`: CPU time (in nanoseconds) spent by tasks of the cgroup in user mode
    - `system`: CPU time (in nanoseconds) spent by tasks of the cgroup in kernel mode
- `cpuacct.usage_percpu`: CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup (including tasks lower in the hierarchy).

Changed behavior when not running in a container:
Before it would return `null` if there was no container running (when reading the file path `sys/fs/cgroup` would return an error).
Now it will actually through an error and let the user know the issue.

Added a function `getAllMetrics` that returns an object of all the metrics.

## How Has This Been Tested?

Added tests in `test/index.test.js`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.