### PR TITLE
semantic-release fix - part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@
 
 language: node_js
 os:
-  - windows
   - linux
+  - windows
   - osx
 
 node_js:
@@ -27,7 +27,7 @@ jobs:
   include:
     - stage: Test
       script: npm test
-    - stage: release
+    - stage: Release
       if: branch = master
       node_js: "12"
       script: skip
@@ -39,7 +39,7 @@ jobs:
           condition:  $TRAVIS_OS_NAME == linux
         provider: script
         skip_cleanup: true
-        script: npx semantic-release --debug
+        script: npm run semantic-release
 
 after_success:
   - npm run report-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-# Copyright 2020 Adobe
-# All Rights Reserved.
+# Copyright 2020 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-# NOTICE: Adobe permits you to use, modify, and distribute this file in
-# accordance with the terms of the Adobe license agreement accompanying
-# it. If you have received this file from a source other than Adobe,
-# then your use, modification, or distribution of it requires the prior
-# written permission of Adobe.
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
 
 language: node_js
 os:
@@ -15,7 +16,6 @@ os:
 
 node_js:
   - "10"
-  - "10.15"
   - "10.19"
   - "12"
   - "14"
@@ -41,5 +41,5 @@ jobs:
         skip_cleanup: true
         script: npm run semantic-release
 
-after_success:
+after_script:
   - npm run report-coverage


### PR DESCRIPTION
Follow up from #23 trying to get it to work.

- order linux first in OS list
- try `after_script` for coverage report, so it doesn't run (and fail) as part of releases