### PR TITLE
[DO NOT MERGE] dummy change for testing disabling of Travis PR job

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+TEST change
+
+
 [![Version](https://img.shields.io/npm/v/@adobe/cgroup-metrics.svg)](https://npmjs.org/package/@adobe/cgroup-metrics)
 
 ### CGROUP-METRICS


### PR DESCRIPTION
I disabled the `Build pushed pull requests` flag to disable the `Travis PR` jobs. Checking if that works as expected using this dummy PR.

- [x] confirm it runs the `Travis branch` job as before (on the branch and for the commit in ths PR)
- [x] confirm it does not run the `Travis PR` job in addition anymore