### PR TITLE
Use parseInt to force radix 10

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ function readandFormatMetric(metric) {
         if (metric === 'memory/memory.stat') {
                 // parse rss
                 const rss = data.split('\n')[1].split(' ')[1];
-                return(parseFloat(rss));
+                return(parseInt(rss, 10));
         }
         if (metric.includes('cpuacct')) {
             const timestamp = getTimestamp();
@@ -38,21 +38,21 @@ function readandFormatMetric(metric) {
                 const system = data.split('\n')[1].split(' ')[1];
                 return {
                     user: {
-                        cpuNanosSinceContainerStart: parseFloat(user),
+                        cpuNanosSinceContainerStart: parseInt(user, 10),
                         timestamp: timestamp
                     },
                     system: {
-                        cpuNanosSinceContainerStart: parseFloat(system),
+                        cpuNanosSinceContainerStart: parseInt(system, 10),
                         timestamp: timestamp
                     }
                 }
             }
             return {
-                cpuNanosSinceContainerStart: parseFloat(data.trim()),
+                cpuNanosSinceContainerStart: parseInt(data.trim(), 10),
                 timestamp: timestamp
             }
         }
-        return(parseFloat(data.trim()));
+        return parseInt(data.trim(), 10);
     } catch (e) {
         throw Error(`Error reading file /sys/fs/cgroup/${metric}, Message: ${e.message || e}`)
     }
@@ -73,4 +73,4 @@ function getTimestamp() {
 module.exports = {
     readandFormatMetric,
     formatMetrics
-}
+};


### PR DESCRIPTION
Favor the usage of parseInt to force radix 10.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use parseInt instead of parseFloat to force the use of radix 10.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.