### PR TITLE
[ON-HOLD] Add function to get container memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Node Module for reading [cgroup](https://www.kernel.org/doc/Documentation/cgroup
 
 Raw values:
 - `stat.rss`: # of bytes of anonymous and swap cache memory
-- `kmem.usage_in_bytes`: current kernel memory allocation
-- `limit_in_bytes`: limit of memory usage
+- `kmem.usage_in_bytes`: current kernel memory allocation in bytes
+- `limit_in_bytes`: limit of memory usage in bytes
 
 Calculated values:
 - `containerUsage()`: `stats.rss` + `kmem.usage_in_bytes`

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -23,7 +23,7 @@ const { readandFormatMetric } = require('./utils');
  * @returns {CpuMetric}
  */
 function usage() {
-	return readandFormatMetric('cpuacct/cpuacct.usage');
+    return readandFormatMetric('cpuacct/cpuacct.usage');
 }
 
 /**
@@ -42,7 +42,7 @@ function usage() {
  *                     }
  */
 function stat() {
-	return readandFormatMetric('cpuacct/cpuacct.stat');
+    return readandFormatMetric('cpuacct/cpuacct.stat');
 }
 
 /**
@@ -52,14 +52,14 @@ function stat() {
  * @returns {Number} cpu usage over a period of time for a specific cpu task
  */
 function calculateUsage(cpuMetricFirst, cpuMetricSecond) {
-	const totalTime = (cpuMetricSecond.timestamp - cpuMetricFirst.timestamp) * 1000000;
-	const deltaNS = cpuMetricSecond.cpuNanosSinceContainerStart - cpuMetricFirst.cpuNanosSinceContainerStart;
-	return deltaNS / totalTime * 100
+    const totalTime = (cpuMetricSecond.timestamp - cpuMetricFirst.timestamp) * 1000000;
+    const deltaNS = cpuMetricSecond.cpuNanosSinceContainerStart - cpuMetricFirst.cpuNanosSinceContainerStart;
+    return deltaNS / totalTime * 100
 }
 
 
 module.exports = {
-	usage,
-	stat,
-	calculateUsage
+    usage,
+    stat,
+    calculateUsage
 }

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -46,10 +46,6 @@ function containerUsagePercentage(memoryContainerUsage = false) {
  * @returns {Number} container memory limit (bytes)
  */
 function containerMemoryLimit(memoryContainerUsage = false) {
-    if (!(memoryContainerUsage)) {
-        memoryContainerUsage = containerUsage();
-    }
-
     let limit = readandFormatMetric('memory/memory.limit_in_bytes');
     if (typeof (limit) !== "number" || (isNaN(limit))) {
         throw Error(`Memory limit metric is malformed: limit: ${limit}`);

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -18,7 +18,7 @@ const UNLIMITED_MEMORY_AMOUNT = 9223372036854771712;
 
 /**
  * Reads metrics from `/sys/fs/cgroup/memory/memory.stat` and `/sys/fs/cgroup/memory/memory.kmem.usage_in_bytes`
- * @returns {Number} container usage based on rss and kmemUsage stats
+ * @returns {Number} container usage based on rss and kmemUsage stats (bytes)
  */
 function containerUsage() {
 	const rss = readandFormatMetric('memory/memory.stat');
@@ -48,7 +48,28 @@ function containerUsagePercentage(memoryContainerUsage=false){
 	return (memoryContainerUsage / limit) * 100;
 }
 
+/**
+ * Reads metrics from `/sys/fs/cgroup/memory`
+ * @returns {Number} container memory limit (bytes)
+ */
+function containerMemoryLimit(memoryContainerUsage=false){
+	if (!(memoryContainerUsage)) {
+		memoryContainerUsage = containerUsage();
+	}
+
+	let limit = readandFormatMetric('memory/memory.limit_in_bytes');
+	if (typeof(limit) !== "number" || (isNaN(limit)) ) {
+		throw Error(`Memory limit metric is malformed: limit: ${limit}`);
+	}
+	// if it's set to unlimited, return the total memory of the host
+	if (limit >= UNLIMITED_MEMORY_AMOUNT || limit === 0) {
+		limit = os.totalmem();
+	}
+	return limit;
+}
+
 module.exports = {
 	containerUsage,
-	containerUsagePercentage
+	containerUsagePercentage,
+    containerMemoryLimit
 }

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -21,48 +21,48 @@ const UNLIMITED_MEMORY_AMOUNT = 9223372036854771712;
  * @returns {Number} container usage based on rss and kmemUsage stats (bytes)
  */
 function containerUsage() {
-	const rss = readandFormatMetric('memory/memory.stat');
-	const kmemUsage = readandFormatMetric('memory/memory.kmem.usage_in_bytes');
-	if (typeof(rss) !== "number" || typeof(kmemUsage) !== "number" || (isNaN(rss)) || (isNaN(kmemUsage)) ) {
-		throw Error(`One or more metrics are malformed. rss: ${rss}, kmemUsage: ${kmemUsage}`);
-	}
-	return (rss + kmemUsage);
+    const rss = readandFormatMetric('memory/memory.stat');
+    const kmemUsage = readandFormatMetric('memory/memory.kmem.usage_in_bytes');
+    if (typeof (rss) !== "number" || typeof (kmemUsage) !== "number" || (isNaN(rss)) || (isNaN(kmemUsage))) {
+        throw Error(`One or more metrics are malformed. rss: ${rss}, kmemUsage: ${kmemUsage}`);
+    }
+    return (rss + kmemUsage);
 }
 
 /**
  * Reads metrics from `/sys/fs/cgroup/memory`
  * @returns {Number} container usage divided by memory limit of the container
  */
-function containerUsagePercentage(memoryContainerUsage=false){
-	if (!(memoryContainerUsage)) {
-		memoryContainerUsage = containerUsage();
-	}
-	const limit = containerMemoryLimit(memoryContainerUsage);
-	return (memoryContainerUsage / limit) * 100;
+function containerUsagePercentage(memoryContainerUsage = false) {
+    if (!(memoryContainerUsage)) {
+        memoryContainerUsage = containerUsage();
+    }
+    const limit = containerMemoryLimit(memoryContainerUsage);
+    return (memoryContainerUsage / limit) * 100;
 }
 
 /**
  * Reads metrics from `/sys/fs/cgroup/memory`
  * @returns {Number} container memory limit (bytes)
  */
-function containerMemoryLimit(memoryContainerUsage=false){
-	if (!(memoryContainerUsage)) {
-		memoryContainerUsage = containerUsage();
-	}
+function containerMemoryLimit(memoryContainerUsage = false) {
+    if (!(memoryContainerUsage)) {
+        memoryContainerUsage = containerUsage();
+    }
 
-	let limit = readandFormatMetric('memory/memory.limit_in_bytes');
-	if (typeof(limit) !== "number" || (isNaN(limit)) ) {
-		throw Error(`Memory limit metric is malformed: limit: ${limit}`);
-	}
-	// if it's set to unlimited, return the total memory of the host
-	if (limit >= UNLIMITED_MEMORY_AMOUNT || limit === 0) {
-		limit = os.totalmem();
-	}
-	return limit;
+    let limit = readandFormatMetric('memory/memory.limit_in_bytes');
+    if (typeof (limit) !== "number" || (isNaN(limit))) {
+        throw Error(`Memory limit metric is malformed: limit: ${limit}`);
+    }
+    // if it's set to unlimited, return the total memory of the host
+    if (limit >= UNLIMITED_MEMORY_AMOUNT || limit === 0) {
+        limit = os.totalmem();
+    }
+    return limit;
 }
 
 module.exports = {
-	containerUsage,
-	containerUsagePercentage,
+    containerUsage,
+    containerUsagePercentage,
     containerMemoryLimit
 }

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -37,7 +37,7 @@ function containerUsagePercentage(memoryContainerUsage = false) {
     if (!(memoryContainerUsage)) {
         memoryContainerUsage = containerUsage();
     }
-    const limit = containerMemoryLimit(memoryContainerUsage);
+    const limit = containerMemoryLimit();
     return (memoryContainerUsage / limit) * 100;
 }
 
@@ -45,7 +45,7 @@ function containerUsagePercentage(memoryContainerUsage = false) {
  * Reads metrics from `/sys/fs/cgroup/memory`
  * @returns {Number} container memory limit (bytes)
  */
-function containerMemoryLimit(memoryContainerUsage = false) {
+function containerMemoryLimit() {
     let limit = readandFormatMetric('memory/memory.limit_in_bytes');
     if (typeof (limit) !== "number" || (isNaN(limit))) {
         throw Error(`Memory limit metric is malformed: limit: ${limit}`);

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -37,14 +37,7 @@ function containerUsagePercentage(memoryContainerUsage=false){
 	if (!(memoryContainerUsage)) {
 		memoryContainerUsage = containerUsage();
 	}
-	let limit = readandFormatMetric('memory/memory.limit_in_bytes');
-	if (typeof(memoryContainerUsage) !== "number" || typeof(limit) !== "number" || (isNaN(memoryContainerUsage)) || (isNaN(limit)) ) {
-		throw Error(`One or more metrics are malformed. containerUsage: ${memoryContainerUsage}, limit: ${limit}`);
-	}
-	// if it's set to unlimited, return the total memory of the host
-	if (limit >= UNLIMITED_MEMORY_AMOUNT || limit === 0) {
-		limit = os.totalmem();
-	}
+	const limit = containerMemoryLimit(memoryContainerUsage);
 	return (memoryContainerUsage / limit) * 100;
 }
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -20,17 +20,17 @@ const memory = require('./memory');
  * @param {Boolean} flatten if true, it returns a on dimensional object
  * @returns {Object} map of each metric to its result
  */
-function metrics(flatten=false) {
+function metrics(flatten = false) {
     const metricsObj = {
-        memory:{},
-        cpuacct:{}
+        memory: {},
+        cpuacct: {}
     };
-	
-    metricsObj.memory.containerUsage           = memory.containerUsage();
+
+    metricsObj.memory.containerUsage = memory.containerUsage();
     metricsObj.memory.containerUsagePercentage = memory.containerUsagePercentage(metricsObj.memory.containerUsage);
 
     metricsObj.cpuacct.usage = cpu.usage();
-    metricsObj.cpuacct.stat  = cpu.stat();
+    metricsObj.cpuacct.stat = cpu.stat();
 
     return formatMetrics(metricsObj, flatten);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,9 +27,9 @@ function readandFormatMetric(metric) {
             throw Error("File is empty");
         }
         if (metric === 'memory/memory.stat') {
-                // parse rss
-                const rss = data.split('\n')[1].split(' ')[1];
-                return(parseInt(rss, 10));
+            // parse rss
+            const rss = data.split('\n')[1].split(' ')[1];
+            return (parseInt(rss, 10));
         }
         if (metric.includes('cpuacct')) {
             const timestamp = getTimestamp();

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it. If you have received this file from a source other than Adobe,
+then your use, modification, or distribution of it requires the prior
+written permission of Adobe.
+*/
+
+'use strict';
+
+/* eslint-env mocha */
+/* eslint mocha/no-mocha-arrows: "off" */
+
+const assert = require('assert');
+// const mockery = require('mockery');
+const mockFs = require('mock-fs');
+const { memory } = require('../index');
+
+const UNLIMITED_MEMORY_AMOUNT = 9223372036854771712;
+
+describe('cgroup memory: container memory limits', function() {
+    beforeEach( () => {
+        mockFs();
+    });
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return the same value as reading the mocked memory value in the file system with containerMemoryLimit', async () => {
+        mockFs({
+            '/sys/fs/cgroup': {
+                'memory': {
+                    'memory.stat':'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.limit_in_bytes': '9999'
+                },
+                'cpuacct': {
+                    'cpuacct.usage': '1000',
+                    'cpuacct.stat': 'user 2000\nsystem 3000\n'
+                }
+            }
+        });
+
+        const containerUsage =  memory.containerMemoryLimit();
+        assert.equal(containerUsage, 9999);
+        assert.equal(typeof containerUsage, "number");
+    });
+
+    // error handling check
+    it('should return the total memory of the host if the memory limit is set to unlimited', async () => {
+        mockFs({
+            '/sys/fs/cgroup/memory': {
+                'memory.stat':'cache 2453\nrss 1234\n',
+                'memory.kmem.usage_in_bytes':'2000',
+                'memory.limit_in_bytes': `${UNLIMITED_MEMORY_AMOUNT}`
+            }
+        });
+        const osMock = require('os');
+        const originalOSTotalMem = osMock.totalmem;
+        osMock.totalmem = function() {
+            return 80000;
+        };
+
+        const containerMemoryLimit = memory.containerMemoryLimit();
+        assert.equal(containerMemoryLimit, 80000)
+        osMock.totalmem = originalOSTotalMem;
+    });
+
+});

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -21,8 +21,8 @@ const { memory } = require('../index');
 
 const UNLIMITED_MEMORY_AMOUNT = 9223372036854771712;
 
-describe('cgroup memory: container memory limits', function() {
-    beforeEach( () => {
+describe('cgroup memory: container memory limits', function () {
+    beforeEach(() => {
         mockFs();
     });
 
@@ -34,8 +34,8 @@ describe('cgroup memory: container memory limits', function() {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -45,7 +45,7 @@ describe('cgroup memory: container memory limits', function() {
             }
         });
 
-        const containerUsage =  memory.containerMemoryLimit();
+        const containerUsage = memory.containerMemoryLimit();
         assert.equal(containerUsage, 9999);
         assert.equal(typeof containerUsage, "number");
     });
@@ -54,14 +54,14 @@ describe('cgroup memory: container memory limits', function() {
     it('should return the total memory of the host if the memory limit is set to unlimited', async () => {
         mockFs({
             '/sys/fs/cgroup/memory': {
-                'memory.stat':'cache 2453\nrss 1234\n',
-                'memory.kmem.usage_in_bytes':'2000',
+                'memory.stat': 'cache 2453\nrss 1234\n',
+                'memory.kmem.usage_in_bytes': '2000',
                 'memory.limit_in_bytes': `${UNLIMITED_MEMORY_AMOUNT}`
             }
         });
         const osMock = require('os');
         const originalOSTotalMem = osMock.totalmem;
-        osMock.totalmem = function() {
+        osMock.totalmem = function () {
             return 80000;
         };
 

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -21,8 +21,8 @@ const { metrics, memory, cpu } = require('../index');
 
 const UNLIMITED_MEMORY_AMOUNT = 9223372036854771712;
 
-describe('cgroup Metrics', function() {
-    beforeEach( () => {
+describe('cgroup Metrics', function () {
+    beforeEach(() => {
         mockFs();
     })
 
@@ -34,8 +34,8 @@ describe('cgroup Metrics', function() {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -45,19 +45,19 @@ describe('cgroup Metrics', function() {
             }
         })
 
-        const containerUsage =  memory.containerUsage();
+        const containerUsage = memory.containerUsage();
         assert.equal(containerUsage, 6666);
 
-        const containerUsagePercentage =  memory.containerUsagePercentage();
-        assert.equal(containerUsagePercentage, 6666/9999 * 100);
+        const containerUsagePercentage = memory.containerUsagePercentage();
+        assert.equal(containerUsagePercentage, 6666 / 9999 * 100);
     });
 
     it('should return the same value as reading the mocked memory value in the file system with containerUsage', async () => {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -67,12 +67,12 @@ describe('cgroup Metrics', function() {
             }
         })
 
-        const containerUsage =  memory.containerUsage();
+        const containerUsage = memory.containerUsage();
         assert.equal(containerUsage, 6666);
         assert.equal(typeof containerUsage, "number");
 
-        const containerUsagePercentage =  memory.containerUsagePercentage(containerUsage);
-        assert.equal(containerUsagePercentage, 6666/9999 * 100);
+        const containerUsagePercentage = memory.containerUsagePercentage(containerUsage);
+        assert.equal(containerUsagePercentage, 6666 / 9999 * 100);
         assert.equal(typeof containerUsagePercentage, "number");
 
     });
@@ -81,8 +81,8 @@ describe('cgroup Metrics', function() {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -132,8 +132,8 @@ describe('cgroup Metrics', function() {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -153,7 +153,7 @@ describe('cgroup Metrics', function() {
         console.log(`CPU user count: ${metrics_object.cpuacct.stat.user}`);
         console.log(`CPU system count: ${metrics_object.cpuacct.stat.system}`);
         assert.equal(metrics_object.memory.containerUsage, 6666);
-        assert.equal(metrics_object.memory.containerUsagePercentage, 6666/9999 * 100);
+        assert.equal(metrics_object.memory.containerUsagePercentage, 6666 / 9999 * 100);
         assert.equal(metrics_object.cpuacct.stat.user.cpuNanosSinceContainerStart, 2000);
         assert.equal(metrics_object.cpuacct.stat.system.cpuNanosSinceContainerStart, 3000);
         assert.equal(metrics_object.cpuacct.usage.cpuNanosSinceContainerStart, 1000);
@@ -163,8 +163,8 @@ describe('cgroup Metrics', function() {
         mockFs({
             '/sys/fs/cgroup': {
                 'memory': {
-                    'memory.stat':'cache 2453\nrss 1234\n',
-                    'memory.kmem.usage_in_bytes':'5432',
+                    'memory.stat': 'cache 2453\nrss 1234\n',
+                    'memory.kmem.usage_in_bytes': '5432',
                     'memory.limit_in_bytes': '9999'
                 },
                 'cpuacct': {
@@ -178,7 +178,7 @@ describe('cgroup Metrics', function() {
         const metrics_object1D = metrics(true);
 
         assert.equal(metrics_object1D['memory.containerUsage'], 6666);
-        assert.equal(metrics_object1D['memory.containerUsagePercentage'], 6666/9999 * 100);
+        assert.equal(metrics_object1D['memory.containerUsagePercentage'], 6666 / 9999 * 100);
         assert.equal(metrics_object1D['cpuacct.stat.user.cpuNanosSinceContainerStart'], 2000);
         assert.equal(metrics_object1D['cpuacct.stat.system.cpuNanosSinceContainerStart'], 3000);
         assert.equal(metrics_object1D['cpuacct.usage.cpuNanosSinceContainerStart'], 1000);
@@ -213,7 +213,7 @@ describe('cgroup Metrics', function() {
     });
 
     it('should throw an error if the file is empty', async () => {
-        mockFs({ '/sys/fs/cgroup/memory/memory.stat':'' })
+        mockFs({ '/sys/fs/cgroup/memory/memory.stat': '' })
 
         try {
             memory.containerUsage();
@@ -227,8 +227,8 @@ describe('cgroup Metrics', function() {
     it('should throw an error if any of memory data is malformed', async () => {
         mockFs({
             '/sys/fs/cgroup/memory': {
-                'memory.stat':'cache 2453\nrss 1234\n',
-                'memory.kmem.usage_in_bytes':'malformed data',
+                'memory.stat': 'cache 2453\nrss 1234\n',
+                'memory.kmem.usage_in_bytes': 'malformed data',
                 'memory.limit_in_bytes': 'malformed data'
             }
         })
@@ -260,8 +260,8 @@ describe('cgroup Metrics', function() {
     it('should throw an error if the stat data is malformed', async () => {
         mockFs({
             '/sys/fs/cgroup': {
-                'memory': { 'memory.stat':'malformed data'},
-                'cpuacct': { 'cpuacct.stat':'malformed data'}
+                'memory': { 'memory.stat': 'malformed data' },
+                'cpuacct': { 'cpuacct.stat': 'malformed data' }
             }
         })
 
@@ -280,7 +280,7 @@ describe('cgroup Metrics', function() {
         threw = false;
 
         try {
-             cpu.stat();
+            cpu.stat();
             assert.fail('failure expected');
         } catch (e) {
             threw = true;
@@ -293,15 +293,15 @@ describe('cgroup Metrics', function() {
     it('should use the total memory of the host if the memory limit is set to unlimited', async () => {
         mockFs({
             '/sys/fs/cgroup/memory': {
-                'memory.stat':'cache 2453\nrss 1234\n',
-                'memory.kmem.usage_in_bytes':'2000',
+                'memory.stat': 'cache 2453\nrss 1234\n',
+                'memory.kmem.usage_in_bytes': '2000',
                 'memory.limit_in_bytes': `${UNLIMITED_MEMORY_AMOUNT}`
             }
         })
         const osMock = require('os');
         const originalOSTotalMem = osMock.totalmem;
 
-        osMock.totalmem = function() {
+        osMock.totalmem = function () {
             return 80000
         }
 

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -253,7 +253,7 @@ describe('cgroup Metrics', function() {
             assert.fail('failure expected');
         } catch (e) {
             console.log(`test expected to fail: ${e}`)
-            assert.equal(e.message, "One or more metrics are malformed. containerUsage: 1234, limit: NaN")
+            assert.equal(e.message, "Memory limit metric is malformed: limit: NaN")
         }
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add function to get container memory limit, so the underlying file where the limit is can easily be read (especially since this library already reads it).

## Related Issue 
DEVOPS

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Add function to get container memory limit, so the underlying file where the limit is can easily be read (especially since this library already reads it). Needed for debugging OOM exceptions,

## How Has This Been Tested?

Unit tests, existing and new ones.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.